### PR TITLE
Removing include of Mongoid::Timestamps

### DIFF
--- a/lib/mongoid/userstamp.rb
+++ b/lib/mongoid/userstamp.rb
@@ -9,8 +9,6 @@ module Mongoid
     autoload :User, 'mongoid/userstamp/user'
 
     included do
-      include Mongoid::Timestamps
-
       field Mongoid::Userstamp.configuration.updated_column, :type => Object
       field Mongoid::Userstamp.configuration.created_column, :type => Object
 


### PR DESCRIPTION
Should not be forced by this gem--user can add it to their model if needed.
