### PR TITLE
Lots of improvements + more test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
-## v0.2.0 (2013-03-24)
+# Changelog
+
+## 0.3.0 - Unreleased
+
+* BREAKING CHANGE: Default value for `updated_accessor` was `:updator`, is now `:updater`, since "updator" is not an English word (@johnnyshields)
+* DEPRECATION: #configure` is now an alias `#config` and is deprecated (@johnnyshields)
+* Replace `Mongoid::Userstamp.configuration` and `Mongoid::Userstamp.configure` with `#config`, which is both a getter and a setter (@johnnyshields)
+* Replace usages of `id` with `_id`, since there are many gems which override the behavior of `id`, for example mongoid_slug (@johnnyshields)
+* Do not overwrite creator if it has already been set manually (@johnnyshields)
+* Define setter methods for updated_accessor/created_accessor which assign the user id. Accepts both `Mongoid::Document` and `BSON::ObjectID` types. (@johnnyshields)
+* Allow pass-in of Mongoid field opts for updated_column/created_column. Useful to set field aliases, default value, etc. (@johnnyshields)
+* Expose current_user as `Mongoid::Userstamp.current_user` (@johnnyshields)
+* Field type is now `::Moped::BSON::ObjectID` instead of Object (@johnnyshields)
+* Catch error if creator/updater has been deleted and return nil (@johnnyshields)
+* Query for creator/updater user using `unscoped` (@johnnyshields)
+* Improve code readability (@johnnyshields)
+* Improve test coverage, including adding tests for config (@johnnyshields)
+
+## 0.2.0 - 2013-03-24
 
 * Added some specs for test coverage
 * Removed dependecy for `Mongoid::Timestamps`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ version above 1.8, so i've written the gem on the new 1.9 hash syntax.
 
  ```ruby
  # Default config
- Mongoid::Userstamp.configure do |c|
+ Mongoid::Userstamp.config do |c|
+
+   # Default config values
+
    c.user_reader = :current_user
    c.user_model = :user
 
@@ -22,7 +25,10 @@ version above 1.8, so i've written the gem on the new 1.9 hash syntax.
    c.created_accessor = :creator
 
    c.updated_column = :updated_by
-   c.updated_accessor = :updator
+   c.updated_accessor = :updater
+
+   # Mongoid field aliases can also be set via c.created_alias and c.updated_alias
+   # (useful when working with minified field names)
  end
 
  # Example model
@@ -35,20 +41,28 @@ version above 1.8, so i've written the gem on the new 1.9 hash syntax.
  p = Person.create
 
  # Updater ObjectID or nil
- p.created_by
- # => BSON::ObjectId('4f7c719f476da850ba000039')
-
- # Updater instance or nil
- p.creator
- # => <User _id: 4f7c719f476da850ba000039>
-
- # Creater ObjectID or nil
  p.updated_by
  # => BSON::ObjectId('4f7c719f476da850ba000039')
 
- # Creater instance or nil
- p.updator
+ # Updater instance or nil
+ p.updater
  # => <User _id: 4f7c719f476da850ba000039>
+
+ # Set updater manually (usually not required)
+ p.updater = my_user   # can be a Mongoid::Document or a BSON::ObjectID
+ # => sets updated_by to my_user's ObjectID
+
+ # Creator ObjectID or nil
+ p.created_by
+ # => BSON::ObjectId('4f7c719f476da850ba000039')
+
+ # Creator instance or nil
+ p.creator
+ # => <User _id: 4f7c719f476da850ba000039>
+
+ # Set creator manually (usually not required)
+ p.creator = my_user   # can be a Mongoid::Document or a BSON::ObjectID
+ # => sets created_by to my_user._id
  ```
 
 ## Credits

--- a/lib/mongoid/userstamp.rb
+++ b/lib/mongoid/userstamp.rb
@@ -9,45 +9,79 @@ module Mongoid
     autoload :User, 'mongoid/userstamp/user'
 
     included do
-      field Mongoid::Userstamp.configuration.updated_column, :type => Object
-      field Mongoid::Userstamp.configuration.created_column, :type => Object
+      field Userstamp.config.updated_column, Userstamp.field_opts(Userstamp.config.updated_column_opts)
+      field Userstamp.config.created_column, Userstamp.field_opts(Userstamp.config.created_column_opts)
 
-      before_save :set_updator
+      before_save :set_updater
       before_create :set_creator
 
-      define_method Mongoid::Userstamp.configuration.updated_accessor do
-        updated_col = self.send(Mongoid::Userstamp.configuration.updated_column)
-        updated_col ? Mongoid::Userstamp.configuration.user_model.find(updated_col) : nil
+      define_method Userstamp.config.updated_accessor do
+        Userstamp.find_user self.send(Userstamp.config.updated_column)
       end
 
-      define_method Mongoid::Userstamp.configuration.created_accessor do
-        created_col = self.send(Mongoid::Userstamp.configuration.created_column)
-        created_col ? Mongoid::Userstamp.configuration.user_model.find(created_col) : nil
+      define_method Userstamp.config.created_accessor do
+        Userstamp.find_user self.send(Userstamp.config.created_column)
+      end
+
+      define_method "#{Userstamp.config.updated_accessor}=" do |user|
+        self.send("#{Userstamp.config.updated_column}=", Userstamp.extract_bson_id(user))
+      end
+
+      define_method "#{Userstamp.config.created_accessor}=" do |user|
+        self.send("#{Userstamp.config.created_column}=", Userstamp.extract_bson_id(user))
       end
 
       protected
-        def set_updator
-          return unless Mongoid::Userstamp.configuration.user_model.respond_to? :current
-          column = "#{Mongoid::Userstamp.configuration.updated_column.to_s}=".to_sym
 
-          self.send(column, Mongoid::Userstamp.configuration.user_model.current.try(:id))
-        end
+      def set_updater
+        return if !Userstamp.has_current_user?
+        self.send("#{Userstamp.config.updated_accessor}=", Userstamp.current_user)
+      end
 
-        def set_creator
-          return unless Mongoid::Userstamp.configuration.user_model.respond_to? :current
-          column = "#{Mongoid::Userstamp.configuration.created_column.to_s}=".to_sym
-
-          self.send(column, Mongoid::Userstamp.configuration.user_model.current.try(:id))
-        end
+      def set_creator
+        return if !Userstamp.has_current_user? || self.send(Userstamp.config.created_column)
+        self.send("#{Userstamp.config.created_accessor}=", Userstamp.current_user)
+      end
     end
 
     class << self
-      def configure(&block)
-        @@configuration = Mongoid::Userstamp::Config.new(&block)
+      def config(&block)
+        if block_given?
+          @@config = Userstamp::Config.new(&block)
+        else
+          @@config ||= Userstamp::Config.new
+        end
+      end
+      alias :configure :config # DEPRECATED
+
+      def field_opts(opts)
+        {type: ::Moped::BSON::ObjectId}.reverse_merge(opts || {})
       end
 
-      def configuration
-        @@configuration ||= Mongoid::Userstamp::Config.new
+      def has_current_user?
+        config.user_model.respond_to?(:current)
+      end
+
+      def current_user
+        config.user_model.try(:current)
+      end
+
+      def extract_bson_id(value)
+        if value.respond_to?(:_id)
+          value.try(:_id)
+        elsif value.present?
+          ::Moped::BSON::ObjectId.from_string(value.to_s)
+        else
+          nil
+        end
+      end
+
+      def find_user(user_id)
+        begin
+          user_id ? Userstamp.config.user_model.unscoped.find(user_id) : nil
+        rescue Mongoid::Errors::DocumentNotFound => e
+          nil
+        end
       end
     end
   end

--- a/lib/mongoid/userstamp/config.rb
+++ b/lib/mongoid/userstamp/config.rb
@@ -3,12 +3,14 @@ module Mongoid
   module Userstamp
     class Config
       attr_accessor :user_reader
-      attr_accessor :user_model
+      attr_writer   :user_model
 
       attr_accessor :created_column
+      attr_accessor :created_column_opts
       attr_accessor :created_accessor
 
       attr_accessor :updated_column
+      attr_accessor :updated_column_opts
       attr_accessor :updated_accessor
 
       def initialize(&block)
@@ -19,7 +21,7 @@ module Mongoid
         @created_accessor = :creator
 
         @updated_column = :updated_by
-        @updated_accessor = :updator
+        @updated_accessor = :updater
 
         instance_eval(&block) if block_given?
       end

--- a/lib/mongoid/userstamp/railtie.rb
+++ b/lib/mongoid/userstamp/railtie.rb
@@ -4,14 +4,14 @@ module Mongoid
     class Railtie < Rails::Railtie
       ActiveSupport.on_load :action_controller do
         before_filter do |c|
-          unless Mongoid::Userstamp.configuration.user_model.respond_to? :current
-            Mongoid::Userstamp.configuration.user_model.send(
+          unless Mongoid::Userstamp.config.user_model.respond_to? :current
+            Mongoid::Userstamp.config.user_model.send(
               :include,
               Mongoid::Userstamp::User
             )
           end
 
-          Mongoid::Userstamp.configuration.user_model.current = c.send(Mongoid::Userstamp.configuration.user_reader)
+          Mongoid::Userstamp.config.user_model.current = c.send(Mongoid::Userstamp.config.user_reader)
         end
       end
     end

--- a/lib/mongoid/userstamp/user.rb
+++ b/lib/mongoid/userstamp/user.rb
@@ -6,7 +6,7 @@ module Mongoid
 
       included do
         def current?
-          !Thread.current[:user].nil? && self.id == Thread.current[:user].id
+          !Thread.current[:user].nil? && self._id == Thread.current[:user]._id
         end
       end
 

--- a/spec/mongoid/userstamp_spec.rb
+++ b/spec/mongoid/userstamp_spec.rb
@@ -1,62 +1,157 @@
 # -*- encoding : utf-8 -*-
 require 'spec_helper'
 
-describe 'Mongoid::Userstamp' do
-  subject {
-    Book.new(
-      name: 'Crafting Rails Applications'
-    )
-  }
+describe Mongoid::Userstamp do
+  subject { Book.new(name: 'Crafting Rails Applications') }
+  let(:user_1) { User.create!(name: 'Charles Dikkens') }
+  let(:user_2) { User.create!(name: 'Edmund Wells') }
 
   it { should respond_to :created_by }
   it { should respond_to :creator }
   it { should respond_to :updated_by }
-  it { should respond_to :updator }
+  it { should respond_to :updater }
+
+  describe '#current_user' do
+    subject{ Mongoid::Userstamp.current_user }
+    context 'when current user is not set' do
+      before { User.current = nil }
+      it { should be_nil }
+    end
+    context 'when current user is set' do
+      before{ User.current = user_1 }
+      it { should eq user_1 }
+    end
+  end
 
   context 'when created without a user' do
-    before {
+    before do
+      User.current = nil
       subject.save!
-    }
-
+    end
     it { subject.created_by.should be_nil }
     it { subject.creator.should be_nil }
     it { subject.updated_by.should be_nil }
-    it { subject.updator.should be_nil }
+    it { subject.updater.should be_nil }
+  end
+
+  context 'when creator is manually set' do
+    before{ User.current = user_1 }
+    context 'set by id' do
+      before do
+        subject.created_by = user_2._id
+        subject.save!
+      end
+      it 'should not be overridden when saved' do
+        subject.created_by.should eq user_2.id
+        subject.creator.should eq user_2
+        subject.updated_by.should eq user_1.id
+        subject.updater.should eq user_1
+      end
+    end
+    context 'set by model' do
+      before do
+        subject.creator = user_2
+        subject.save!
+      end
+      it 'should not be overridden when saved' do
+        subject.created_by.should eq user_2.id
+        subject.creator.should eq user_2
+        subject.updated_by.should eq user_1.id
+        subject.updater.should eq user_1
+      end
+    end
   end
 
   context 'when created by a user' do
-    let(:user_1) {
-      User.create!(
-        name: 'Charles Dikkens'
-      )
-    }
-
-    before {
+    before do
       User.current = user_1
-      subject.save
-    }
+      subject.save!
+    end
 
     it { subject.created_by.should == user_1.id }
     it { subject.creator.should == user_1 }
     it { subject.updated_by.should == user_1.id }
-    it { subject.updator.should == user_1 }
+    it { subject.updater.should == user_1 }
 
     context 'when updated by a user' do
-      let(:user_2) {
-        User.create!(
-          name: 'Edmund Wells'
-        )
-      }
-
-      before {
+      before do
         User.current = user_2
         subject.save!
-      }
+      end
 
       it { subject.created_by.should == user_1.id }
       it { subject.creator.should == user_1 }
       it { subject.updated_by.should == user_2.id }
-      it { subject.updator.should == user_2 }
+      it { subject.updater.should == user_2 }
+    end
+
+    context 'when user has been destroyed' do
+      before do
+        User.current = user_2
+        subject.save!
+        user_1.destroy
+        user_2.destroy
+      end
+
+      it { subject.created_by.should == user_1.id }
+      it { subject.creator.should == nil }
+      it { subject.updated_by.should == user_2.id }
+      it { subject.updater.should == nil }
     end
   end
+
+  describe '#config' do
+    before do
+      Mongoid::Userstamp.config do |c|
+        c.user_reader = :current_user
+        c.user_model  = :user
+
+        c.created_column   = :c_by
+        c.created_column_opts = {as: :created_by_id}
+        c.created_accessor = :created_by
+
+        c.updated_column   = :u_by
+        c.updated_column_opts = {as: :updated_by_id}
+        c.updated_accessor = :updated_by
+      end
+
+      # class definition must come after config
+      class Novel
+        include Mongoid::Document
+        include Mongoid::Userstamp
+
+        field :name
+      end
+    end
+    subject { Novel.new(name: 'Ethyl the Aardvark goes Quantity Surveying') }
+
+    context 'when created by a user' do
+      before do
+        User.current = user_1
+        subject.save!
+      end
+
+      it { subject.c_by.should == user_1.id }
+      it { subject.created_by_id.should == user_1.id }
+      it { subject.created_by.should == user_1 }
+      it { subject.u_by.should == user_1.id }
+      it { subject.updated_by_id.should == user_1.id }
+      it { subject.updated_by.should == user_1 }
+
+      context 'when updated by a user' do
+        before do
+          User.current = user_2
+          subject.save!
+        end
+
+        it { subject.c_by.should == user_1.id }
+        it { subject.created_by_id.should == user_1.id }
+        it { subject.created_by.should == user_1 }
+        it { subject.u_by.should == user_2.id }
+        it { subject.updated_by_id.should == user_2.id }
+        it { subject.updated_by.should == user_2 }
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
- BREAKING CHANGE: Default value for `updated_accessor` was `:updator`, is now `:updater`, since "updator" is not an English word
- DEPRECATION: #configure`is now an alias`#config` and is deprecated
- Replace `Mongoid::Userstamp.configuration` and `Mongoid::Userstamp.configure` with `#config`, which is both a getter and a setter
- Replace usages of `id` with `_id`, since there are many gems which override the behavior of `id`, for example mongoid_slug
- Do not overwrite creator if it has already been set manually
- Define setter methods for updated_accessor/created_accessor which assign the user id. Accepts both Mongoid::Document and BSON::ObjectID.
- Allow pass-in of Mongoid field opts for updated_column/created_column. Useful to set field aliases, default value, etc.
- Expose current_user as Mongoid::Userstamp.current_user
- Field type is now ::Moped::BSON::ObjectID instead of Object
- Catch error if creator/updater has been deleted and return nil
- Query for creator/updater user using `unscoped`
- Improve code readability
- Improve test coverage, including adding tests for config
